### PR TITLE
Add dataset analysis entity and repository

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -41,6 +41,9 @@ The database shared common dependency is already included in https://github.com/
 </dependency>
 ----
 
+== Dataset analysis
+The `DatasetAnalysisEntity` stores evaluated datasets including the dataset URI, the timestamp of the analysis and its status. Ratings can be saved numerically or as free text. The corresponding RDF result is kept as a blob in `DatasetAnalysisEntityLobs` and can be accessed through `DatasetAnalysisRepository`.
+
 
 == Contribute
 

--- a/src/main/java/de/leipzig/htwk/gitrdf/database/common/entity/DatasetAnalysisEntity.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/database/common/entity/DatasetAnalysisEntity.java
@@ -1,0 +1,32 @@
+package de.leipzig.htwk.gitrdf.database.common.entity;
+
+import de.leipzig.htwk.gitrdf.database.common.entity.enums.DatasetAnalysisStatus;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "datasetanalysis")
+@Data
+@NoArgsConstructor
+public class DatasetAnalysisEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 1000)
+    private String datasetUri;
+
+    private LocalDateTime analysisTimestamp;
+
+    @Enumerated(EnumType.STRING)
+    private DatasetAnalysisStatus status;
+
+    private Double ratingNumber;
+
+    @Column(length = 1024)
+    private String ratingText;
+}

--- a/src/main/java/de/leipzig/htwk/gitrdf/database/common/entity/enums/DatasetAnalysisStatus.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/database/common/entity/enums/DatasetAnalysisStatus.java
@@ -1,0 +1,8 @@
+package de.leipzig.htwk.gitrdf.database.common.entity.enums;
+
+public enum DatasetAnalysisStatus {
+    PENDING,
+    RUNNING,
+    DONE,
+    FAILED
+}

--- a/src/main/java/de/leipzig/htwk/gitrdf/database/common/entity/lob/DatasetAnalysisEntityLobs.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/database/common/entity/lob/DatasetAnalysisEntityLobs.java
@@ -1,0 +1,24 @@
+package de.leipzig.htwk.gitrdf.database.common.entity.lob;
+
+import de.leipzig.htwk.gitrdf.database.common.entity.DatasetAnalysisEntity;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.sql.Blob;
+
+@Entity
+@Data
+@NoArgsConstructor
+public class DatasetAnalysisEntityLobs {
+
+    @Id
+    private Long id;
+
+    @OneToOne
+    @MapsId
+    private DatasetAnalysisEntity analysisEntity;
+
+    @Lob
+    private Blob rdfFile;
+}

--- a/src/main/java/de/leipzig/htwk/gitrdf/database/common/repository/DatasetAnalysisRepository.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/database/common/repository/DatasetAnalysisRepository.java
@@ -1,0 +1,7 @@
+package de.leipzig.htwk.gitrdf.database.common.repository;
+
+import de.leipzig.htwk.gitrdf.database.common.entity.DatasetAnalysisEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DatasetAnalysisRepository extends JpaRepository<DatasetAnalysisEntity, Long> {
+}


### PR DESCRIPTION
## Summary
- add `DatasetAnalysisEntity` and blob entity for RDF analysis results
- provide JPA repository `DatasetAnalysisRepository`
- support dataset analysis states via new `DatasetAnalysisStatus` enum
- document dataset analysis usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6866fcf761b8832b85cc3c94a99c1af8