### PR TITLE
Add dataset URI tracking to Github orders

### DIFF
--- a/src/main/java/de/leipzig/htwk/gitrdf/database/common/entity/GithubRepositoryOrderEntity.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/database/common/entity/GithubRepositoryOrderEntity.java
@@ -14,7 +14,9 @@ public class GithubRepositoryOrderEntity {
     public static GithubRepositoryOrderEntity newOrder(
             String ownerName,
             String repositoryName,
-            GithubRepositoryFilter githubRepositoryFilter) {
+            GithubRepositoryFilter githubRepositoryFilter,
+            String datasetUri,
+            Integer analysisRating) {
 
         GithubRepositoryOrderEntity githubRepositoryOrderEntity = new GithubRepositoryOrderEntity();
 
@@ -23,6 +25,8 @@ public class GithubRepositoryOrderEntity {
         githubRepositoryOrderEntity.setNumberOfTries(0);
         githubRepositoryOrderEntity.setStatus(GitRepositoryOrderStatus.RECEIVED);
         githubRepositoryOrderEntity.setGithubRepositoryFilter(githubRepositoryFilter);
+        githubRepositoryOrderEntity.setDatasetUri(datasetUri);
+        githubRepositoryOrderEntity.setAnalysisRating(analysisRating);
 
         return githubRepositoryOrderEntity;
     }
@@ -36,6 +40,12 @@ public class GithubRepositoryOrderEntity {
 
     @Column(nullable = false, length = 255)
     private String repositoryName;
+
+    @Column(length = 2048)
+    private String datasetUri;
+
+    @Column
+    private Integer analysisRating;
 
     @Enumerated(EnumType.STRING)
     private GitRepositoryOrderStatus status;

--- a/src/main/java/de/leipzig/htwk/gitrdf/database/common/entity/lob/GithubRepositoryOrderEntityLobs.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/database/common/entity/lob/GithubRepositoryOrderEntityLobs.java
@@ -21,4 +21,7 @@ public class GithubRepositoryOrderEntityLobs {
 
     @Lob
     private Blob rdfFile;
+
+    @Lob
+    private Blob analysisRdfFile;
 }

--- a/src/main/java/de/leipzig/htwk/gitrdf/database/common/repository/GithubRepositoryOrderRepository.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/database/common/repository/GithubRepositoryOrderRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface GithubRepositoryOrderRepository extends JpaRepository<GithubRepositoryOrderEntity, Long> {
 
     List<GithubRepositoryOrderEntity> findAllByStatus(GitRepositoryOrderStatus status);
+
+    List<GithubRepositoryOrderEntity> findAllByDatasetUri(String datasetUri);
 }


### PR DESCRIPTION
## Summary
- allow storing dataset URI and analysis rating in `GithubRepositoryOrderEntity`
- add optional analysis RDF file to `GithubRepositoryOrderEntityLobs`
- support lookups by dataset URI in `GithubRepositoryOrderRepository`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866fcf8e530832bb0e746299c04c8e1