### PR TITLE
Add per-analysis rating storage

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -42,7 +42,7 @@ The database shared common dependency is already included in https://github.com/
 ----
 
 == Repository analysis
-Each `GithubRepositoryOrderEntity` can be linked to multiple `RepositoryAnalysisEntity` objects.  An analysis stores optional parameters such as `modelName`, `temperature`, and `experimentName` and may hold aggregated ratings (`ratingNumber` or `ratingText`).  Every analysis keeps several `LlmRatingRunEntity` objects, each persisting its RDF output in the associated `LlmRatingRunEntityLobs` entry.  The aggregated RDF of an analysis is stored via `RepositoryAnalysisEntityLobs`.
+Each `GithubRepositoryOrderEntity` can be linked to multiple `RepositoryAnalysisEntity` objects.  An analysis stores optional parameters such as `modelName`, `temperature`, and `experimentName` and may hold aggregated ratings (`ratingNumber` or `ratingText`).  Every analysis keeps several `LlmRatingRunEntity` objects, each persisting its RDF output in the associated `LlmRatingRunEntityLobs` entry.  Individual rating results are saved as `RepositoryRatingEntity` objects, while the aggregated RDF of an analysis is stored via `RepositoryAnalysisEntityLobs`.
 
 
 == Contribute

--- a/src/main/java/de/leipzig/htwk/gitrdf/database/common/entity/RepositoryAnalysisEntity.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/database/common/entity/RepositoryAnalysisEntity.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -79,6 +80,9 @@ public class RepositoryAnalysisEntity {
   @OneToMany(mappedBy = "repositoryAnalysis", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
   private List<LlmRatingRunEntity> llmRatingRuns = new ArrayList<>();
 
+  @OneToMany(mappedBy = "repositoryAnalysis", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  private List<RepositoryRatingEntity> ratings = new ArrayList<>();
+
   @PreUpdate
   public void preUpdate() {
     this.updatedAt = LocalDateTime.now();
@@ -90,9 +94,19 @@ public class RepositoryAnalysisEntity {
     llmRatingRun.setRepositoryAnalysis(this);
   }
 
+  public void addRating(RepositoryRatingEntity rating) {
+    ratings.add(rating);
+    rating.setRepositoryAnalysis(this);
+  }
+
   public void removeLlmRatingRun(LlmRatingRunEntity llmRatingRun) {
     llmRatingRuns.remove(llmRatingRun);
     llmRatingRun.setRepositoryAnalysis(null);
+  }
+
+  public void removeRating(RepositoryRatingEntity rating) {
+    ratings.remove(rating);
+    rating.setRepositoryAnalysis(null);
   }
 
   // Constructor with all analysis parameters

--- a/src/main/java/de/leipzig/htwk/gitrdf/database/common/entity/RepositoryRatingEntity.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/database/common/entity/RepositoryRatingEntity.java
@@ -1,0 +1,53 @@
+package de.leipzig.htwk.gitrdf.database.common.entity;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "repository_analysis_rating")
+@Data
+@NoArgsConstructor
+public class RepositoryRatingEntity {
+
+  public static RepositoryRatingEntity newRating(
+      RepositoryAnalysisEntity repositoryAnalysis,
+      BigDecimal ratingNumber,
+      String ratingText) {
+    RepositoryRatingEntity rating = new RepositoryRatingEntity();
+    rating.setRepositoryAnalysis(repositoryAnalysis);
+    rating.setRatingNumber(ratingNumber);
+    rating.setRatingText(ratingText);
+    rating.setCreatedAt(LocalDateTime.now());
+    return rating;
+  }
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "repository_analysis_id", nullable = false)
+  private RepositoryAnalysisEntity repositoryAnalysis;
+
+  @Column(name = "rating_number", precision = 10, scale = 4)
+  private BigDecimal ratingNumber;
+
+  @Column(name = "rating_text", columnDefinition = "TEXT")
+  private String ratingText;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/de/leipzig/htwk/gitrdf/database/common/repository/RepositoryRatingRepository.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/database/common/repository/RepositoryRatingRepository.java
@@ -1,0 +1,15 @@
+package de.leipzig.htwk.gitrdf.database.common.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import de.leipzig.htwk.gitrdf.database.common.entity.RepositoryAnalysisEntity;
+import de.leipzig.htwk.gitrdf.database.common.entity.RepositoryRatingEntity;
+
+public interface RepositoryRatingRepository extends JpaRepository<RepositoryRatingEntity, Long> {
+
+  List<RepositoryRatingEntity> findByRepositoryAnalysis(RepositoryAnalysisEntity repositoryAnalysis);
+
+  List<RepositoryRatingEntity> findByRepositoryAnalysisId(Long repositoryAnalysisId);
+}


### PR DESCRIPTION
## Summary
- define `RepositoryRatingEntity` and its repository
- allow `RepositoryAnalysisEntity` to store and manage individual ratings
- document the new rating entity in README

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871890be654832bb54ab7ee466f645d