### PR TITLE
Add github task ratings

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -44,6 +44,12 @@ The database shared common dependency is already included in https://github.com/
 == Repository analysis
 Each `GithubRepositoryOrderEntity` can be linked to multiple `RepositoryAnalysisEntity` objects.  An analysis stores optional parameters such as `modelName`, `temperature`, and `experimentName` and may hold aggregated ratings (`ratingNumber` or `ratingText`).  Every analysis keeps several `LlmRatingRunEntity` objects, each persisting its RDF output in the associated `LlmRatingRunEntityLobs` entry.  Individual rating results are saved as `RepositoryRatingEntity` objects, while the aggregated RDF of an analysis is stored via `RepositoryAnalysisEntityLobs`.
 
+== Github order ratings
+`GithubRepositoryOrderEntity` can directly store feedback in
+`GithubRepositoryOrderRatingEntity` objects.  Every rating is identified by a
+`ratingIdentifier` (UUID) and may contain a numeric value and text.  Ratings are
+queryable by the task id or by their unique identifier.
+
 
 == Contribute
 

--- a/src/main/java/de/leipzig/htwk/gitrdf/database/common/entity/GithubRepositoryOrderEntity.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/database/common/entity/GithubRepositoryOrderEntity.java
@@ -10,6 +10,12 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.FetchType;
+import de.leipzig.htwk.gitrdf.database.common.entity.GithubRepositoryOrderRatingEntity;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -52,5 +58,18 @@ public class GithubRepositoryOrderEntity {
 
     @Embedded
     private GithubRepositoryFilter githubRepositoryFilter;
+
+    @OneToMany(mappedBy = "githubRepositoryOrder", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<GithubRepositoryOrderRatingEntity> ratings = new ArrayList<>();
+
+    public void addRating(GithubRepositoryOrderRatingEntity rating) {
+        ratings.add(rating);
+        rating.setGithubRepositoryOrder(this);
+    }
+
+    public void removeRating(GithubRepositoryOrderRatingEntity rating) {
+        ratings.remove(rating);
+        rating.setGithubRepositoryOrder(null);
+    }
 
 }

--- a/src/main/java/de/leipzig/htwk/gitrdf/database/common/entity/GithubRepositoryOrderRatingEntity.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/database/common/entity/GithubRepositoryOrderRatingEntity.java
@@ -1,0 +1,57 @@
+package de.leipzig.htwk.gitrdf.database.common.entity;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "github_repository_order_rating")
+@Data
+@NoArgsConstructor
+public class GithubRepositoryOrderRatingEntity {
+
+  public static GithubRepositoryOrderRatingEntity newRating(
+      GithubRepositoryOrderEntity githubRepositoryOrder,
+      String ratingIdentifier,
+      BigDecimal ratingNumber,
+      String ratingText) {
+    GithubRepositoryOrderRatingEntity rating = new GithubRepositoryOrderRatingEntity();
+    rating.setGithubRepositoryOrder(githubRepositoryOrder);
+    rating.setRatingIdentifier(ratingIdentifier);
+    rating.setRatingNumber(ratingNumber);
+    rating.setRatingText(ratingText);
+    rating.setCreatedAt(LocalDateTime.now());
+    return rating;
+  }
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "github_repository_order_id", nullable = false)
+  private GithubRepositoryOrderEntity githubRepositoryOrder;
+
+  @Column(name = "rating_identifier", nullable = false, length = 255, unique = true)
+  private String ratingIdentifier;
+
+  @Column(name = "rating_number", precision = 10, scale = 4)
+  private BigDecimal ratingNumber;
+
+  @Column(name = "rating_text", columnDefinition = "TEXT")
+  private String ratingText;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+}

--- a/src/main/java/de/leipzig/htwk/gitrdf/database/common/repository/GithubRepositoryOrderRatingRepository.java
+++ b/src/main/java/de/leipzig/htwk/gitrdf/database/common/repository/GithubRepositoryOrderRatingRepository.java
@@ -1,0 +1,17 @@
+package de.leipzig.htwk.gitrdf.database.common.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import de.leipzig.htwk.gitrdf.database.common.entity.GithubRepositoryOrderEntity;
+import de.leipzig.htwk.gitrdf.database.common.entity.GithubRepositoryOrderRatingEntity;
+
+public interface GithubRepositoryOrderRatingRepository extends JpaRepository<GithubRepositoryOrderRatingEntity, Long> {
+
+    List<GithubRepositoryOrderRatingEntity> findByGithubRepositoryOrder(GithubRepositoryOrderEntity githubRepositoryOrder);
+
+    List<GithubRepositoryOrderRatingEntity> findByGithubRepositoryOrderId(Long githubRepositoryOrderId);
+
+    GithubRepositoryOrderRatingEntity findByRatingIdentifier(String ratingIdentifier);
+}


### PR DESCRIPTION
## Summary
- add `GithubRepositoryOrderRatingEntity` to persist ratings for tasks
- link ratings to `GithubRepositoryOrderEntity`
- expose repository `GithubRepositoryOrderRatingRepository`
- document task rating feature in README

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68718e534f9c832b9ec5f322bc632877